### PR TITLE
Improve annotation UI

### DIFF
--- a/static/annotation.js
+++ b/static/annotation.js
@@ -5,6 +5,49 @@ const pdfCtx      = pdfCanvas.getContext('2d');
 // Enable selection for multi-select
 const fabricCanvas = new fabric.Canvas(drawCanvas, { selection: true, backgroundColor: 'transparent' });
 
+let isCtrlDown = false;
+let clipboard = [];
+
+document.addEventListener('keydown', e => {
+    if (e.key === 'Control') isCtrlDown = true;
+});
+
+document.addEventListener('keyup', e => {
+    if (e.key === 'Control') isCtrlDown = false;
+});
+
+// Keyboard helpers (copy/paste & arrows)
+document.addEventListener('keydown', e => {
+    const objs = fabricCanvas.getActiveObjects();
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'c') {
+        clipboard = objs.map(o => o.clone());
+        e.preventDefault();
+        return;
+    }
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'v') {
+        clipboard.forEach(cl => {
+            cl.clone(c => {
+                c.set({ left: c.left + 20, top: c.top + 20 });
+                fabricCanvas.add(c);
+            });
+        });
+        fabricCanvas.discardActiveObject();
+        fabricCanvas.renderAll();
+        updateBoxList();
+        e.preventDefault();
+        return;
+    }
+    if (objs.length > 0) {
+        let moved = false;
+        const step = e.shiftKey ? 10 : 1;
+        if (e.key === 'ArrowLeft')  { objs.forEach(o => { o.left -= step; o.setCoords(); }); moved=true; }
+        if (e.key === 'ArrowRight') { objs.forEach(o => { o.left += step; o.setCoords(); }); moved=true; }
+        if (e.key === 'ArrowUp')    { objs.forEach(o => { o.top  -= step; o.setCoords(); }); moved=true; }
+        if (e.key === 'ArrowDown')  { objs.forEach(o => { o.top  += step; o.setCoords(); }); moved=true; }
+        if (moved) { fabricCanvas.renderAll(); updateBoxList(); e.preventDefault(); }
+    }
+});
+
 let pdfDoc=null, pageNum=1, scale=1.2;
 
 function renderPage(num){

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"/>
     <style>
         body{font-family:Arial, sans-serif;margin:0;padding:0;}
-        #toolbar{background:#333;color:#fff;padding:8px;}
-        #canvas-container{position:relative;width:100%;text-align:center;}
+        #toolbar{background:#333;color:#fff;padding:8px;display:flex;gap:10px;align-items:center;}
+        #instructions{font-size:0.8em;color:#ddd;margin-left:auto;}
+        #canvas-container{position:relative;width:100%;text-align:center;margin-top:10px;}
         canvas{border:1px solid #999;}
-        #box-list{max-height:150px;overflow:auto;font-size:0.9em;}
+        #box-list{max-height:150px;overflow:auto;font-size:0.9em;margin-top:10px;}
         .hidden{display:none;}
     </style>
 </head>
@@ -17,7 +18,8 @@
 <div id="toolbar">
     <button onclick="showAnnotate()">Annotate</button>
     <button onclick="showExtract()">Extract</button>
-    <button onclick="duplicateBox()">Duplicate Box</button>
+    <button onclick="duplicateBox()">Copy Selected</button>
+    <span id="instructions">Ctrl+click to multi-select &mdash; use arrows to move, Ctrl+C/Ctrl+V to copy</span>
 </div>
 <!-- Annotate Mode -->
 <div id="annotate-pane">
@@ -32,6 +34,7 @@
     </div>
     <h3>Boxes</h3>
     <div id="box-list"></div>
+    <p style="font-size:0.8em;color:#555;margin-top:10px;">Draw rectangles to create boxes. Use the toolbar tips for copy and movement.</p>
 </div>
 <!-- Extract Mode -->
 <div id="extract-pane" class="hidden">


### PR DESCRIPTION
## Summary
- add keyboard shortcuts and copy/paste support to annotation tool
- tweak toolbar and add UI tips
- clarify instructions

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6861aa4c918483238118204456aa3f6a